### PR TITLE
Feature/mem optimization v2

### DIFF
--- a/Scribe/FontSystem.cs
+++ b/Scribe/FontSystem.cs
@@ -423,7 +423,7 @@ namespace Prowl.Scribe
 
         public Vector2 MeasureText(string text, float pixelSize, FontFile font, float letterSpacing = 0)
         {
-            var settings = TextLayoutSettings.Default;
+            var settings = TextLayoutSettings.Get();
             settings.PixelSize = pixelSize;
             settings.Font = font;
             settings.LetterSpacing = letterSpacing;
@@ -440,7 +440,7 @@ namespace Prowl.Scribe
 
         public void DrawText(string text, Vector2 position, FontColor color, float pixelSize, FontFile font, float letterSpacing = 0)
         {
-            var settings = TextLayoutSettings.Default;
+            var settings = TextLayoutSettings.Get();
             settings.PixelSize = pixelSize;
             settings.Font = font;
             settings.LetterSpacing = letterSpacing;

--- a/Scribe/FontSystem.cs
+++ b/Scribe/FontSystem.cs
@@ -520,7 +520,6 @@ namespace Prowl.Scribe
                 #else
                 renderer.DrawQuads(atlasTexture, vertices.ToArray(), indices.ToArray());
 #endif
-                
             }
             
             _textLayouts.Push(layout);

--- a/Scribe/FontSystem.cs
+++ b/Scribe/FontSystem.cs
@@ -389,14 +389,14 @@ namespace Prowl.Scribe
         {
             if (string.IsNullOrEmpty(text))
             {
-                var empty = GetTextLayoutFromPool();
+                var empty = TextLayout.Get();
                 empty.UpdateLayout(text, settings, this);
                 return empty;
             }
 
             if (!CacheLayouts)
             {
-                var direct = GetTextLayoutFromPool();
+                var direct = TextLayout.Get();
                 direct.UpdateLayout(text, settings, this);
                 return direct;
             }
@@ -406,7 +406,7 @@ namespace Prowl.Scribe
             if (layoutCache.TryGetValue(key, out var cached))
                 return cached;
 
-            var layout = GetTextLayoutFromPool();
+            var layout = TextLayout.Get();
             layout.UpdateLayout(text, settings, this);
 
             layoutCache.Add(key, layout);
@@ -457,18 +457,6 @@ namespace Prowl.Scribe
             DrawLayout(layout, position, color);
         }
 
-        private Stack<TextLayout> _textLayouts = new Stack<TextLayout>();
-
-        private TextLayout GetTextLayoutFromPool()
-        {
-            if (_textLayouts.TryPop(out TextLayout layout))
-            {
-                return layout;
-            }
-
-            return new TextLayout();
-        }
-        
         List<IFontRenderer.Vertex> _vertices = new List<IFontRenderer.Vertex>();
         List<int> _indices = new List<int>();
         public void DrawLayout(TextLayout layout, Vector2 position, FontColor color)
@@ -522,7 +510,7 @@ namespace Prowl.Scribe
 #endif
             }
             
-            _textLayouts.Push(layout);
+            TextLayout.Return(layout);
         }
 
         #endregion

--- a/Scribe/FontSystem.cs
+++ b/Scribe/FontSystem.cs
@@ -457,12 +457,17 @@ namespace Prowl.Scribe
             DrawLayout(layout, position, color);
         }
 
+        
+        List<IFontRenderer.Vertex> _vertices = new List<IFontRenderer.Vertex>();
+        List<int> _indices = new List<int>();
         public void DrawLayout(TextLayout layout, Vector2 position, FontColor color)
         {
             if (layout.Lines.Count == 0) return;
 
-            var vertices = new List<IFontRenderer.Vertex>();
-            var indices = new List<int>();
+            _vertices.Clear();
+            var vertices = _vertices;
+            _indices.Clear();
+            var indices = _indices;
             int vertexCount = 0;
 
             foreach (var line in layout.Lines)
@@ -487,7 +492,12 @@ namespace Prowl.Scribe
                     vertices.Add(new IFontRenderer.Vertex(new Vector3(glyphX + glyphW, glyphY + glyphH, 0), color, new Vector2(glyph.U1, glyph.V1)));
 
                     // Create quad indices
-                    indices.AddRange(new[] { vertexCount, vertexCount + 1, vertexCount + 2, vertexCount + 1, vertexCount + 3, vertexCount + 2 });
+                    indices.Add(vertexCount);
+                    indices.Add(vertexCount + 1);
+                    indices.Add(vertexCount + 2);
+                    indices.Add(vertexCount + 1);
+                    indices.Add(vertexCount + 3);
+                    indices.Add(vertexCount + 2);
                     vertexCount += 4;
                 }
             }

--- a/Scribe/FontSystem.cs
+++ b/Scribe/FontSystem.cs
@@ -429,6 +429,7 @@ namespace Prowl.Scribe
             settings.LetterSpacing = letterSpacing;
 
             var layout = CreateLayout(text, settings);
+            TextLayoutSettings.Return(settings);
             return layout.Size;
         }
 
@@ -446,6 +447,8 @@ namespace Prowl.Scribe
             settings.LetterSpacing = letterSpacing;
 
             DrawText(text, position, color, settings);
+            
+            TextLayoutSettings.Return(settings);
         }
 
 

--- a/Scribe/Internal/Bitmap.cs
+++ b/Scribe/Internal/Bitmap.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Numerics;
 using static Prowl.Scribe.Internal.Common;
 
@@ -327,8 +328,9 @@ namespace Prowl.Scribe.Internal
             for (int i = 0; i < windings; ++i) totalEdges += wcount[i];
 
             // +1 sentinel edge
-            var edges = new Edge[totalEdges + 1];
-            for (int i = 0; i < edges.Length; ++i) edges[i] = new Edge();
+            int edgesLength = totalEdges + 1;
+            var edges = ArrayPool<Edge>.Shared.Rent(edgesLength);
+            for (int i = 0; i < edgesLength; ++i) edges[i] = new Edge();
 
             int n = 0; // number of produced edges
             int m = 0; // running index into pts per winding
@@ -368,6 +370,8 @@ namespace Prowl.Scribe.Internal
             SortEdgesInsSort(edgePtr, n);
 
             RasterizeSortedEdges(edgePtr, n, vsubsample, offX, offY);
+            
+            ArrayPool<Edge>.Shared.Return(edges);
         }
 
         private Vector2[] FlattenCurves(GlyphVertex[] vertices, int numVerts, float objspaceFlatness, out int[] contourLengths, out int numContours)

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -1016,7 +1016,7 @@ namespace Prowl.Scribe
                 int gCount = glyphs.Count;
                 if (gCount == 0) continue;
 
-                var g2t = new int[gCount];
+                var g2t = ArrayPool<int>.Shared.Rent(gCount);
                 for (int gi = 0; gi < gCount; gi++)
                 {
                     char gc = glyphs[gi].Character;
@@ -1044,6 +1044,8 @@ namespace Prowl.Scribe
                     float h = line.Height;
                     dl.Links.Add(new LinkInfo(new RectangleF(x0, y0, x1 - x0, h), l.Href));
                 }
+                
+                ArrayPool<int>.Shared.Return(g2t);
             }
         }
 

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -247,6 +247,8 @@ namespace Prowl.Scribe
                     renderer.DrawQuads(img.Texture, _vertsImg, _idxImg);
                 }
             }
+            
+            GlyphInstance.ResetLayoutCount();
         }
 
         static IFontRenderer.Vertex[] _vertsImg = new IFontRenderer.Vertex[4];
@@ -507,6 +509,7 @@ namespace Prowl.Scribe
 
                     var tl = fontSystem.CreateLayout(text, tls);
                     minCol[c] = MathF.Max(minCol[c], tl.Size.X);
+                    TextLayout.Return(tl);
                 }
             }
 

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -234,20 +234,21 @@ namespace Prowl.Scribe
                 }
                 else if (op is DrawImage img)
                 {
-                    var vertsImg = new IFontRenderer.Vertex[4];
-                    var idxImg = new int[] { 0, 2, 1, 1, 2, 3 };
                     var r = img.Rect;
                     float offsetX = r.X + position.X;
                     float offsetY = r.Y + position.Y;
-                    vertsImg[0] = new IFontRenderer.Vertex(new Vector3(offsetX, offsetY, 0), FontColor.White, new Vector2(0, 0));
-                    vertsImg[1] = new IFontRenderer.Vertex(new Vector3(offsetX + r.Width, offsetY, 0), FontColor.White, new Vector2(1, 0));
-                    vertsImg[2] = new IFontRenderer.Vertex(new Vector3(offsetX, offsetY + r.Height, 0), FontColor.White, new Vector2(0, 1));
-                    vertsImg[3] = new IFontRenderer.Vertex(new Vector3(offsetX + r.Width, offsetY + r.Height, 0), FontColor.White, new Vector2(1, 1));
-                    renderer.DrawQuads(img.Texture, vertsImg, idxImg);
+                    _vertsImg[0] = new IFontRenderer.Vertex(new Vector3(offsetX, offsetY, 0), FontColor.White, new Vector2(0, 0));
+                    _vertsImg[1] = new IFontRenderer.Vertex(new Vector3(offsetX + r.Width, offsetY, 0), FontColor.White, new Vector2(1, 0));
+                    _vertsImg[2] = new IFontRenderer.Vertex(new Vector3(offsetX, offsetY + r.Height, 0), FontColor.White, new Vector2(0, 1));
+                    _vertsImg[3] = new IFontRenderer.Vertex(new Vector3(offsetX + r.Width, offsetY + r.Height, 0), FontColor.White, new Vector2(1, 1));
+                    renderer.DrawQuads(img.Texture, _vertsImg, _idxImg);
                 }
             }
         }
 
+        static IFontRenderer.Vertex[] _vertsImg = new IFontRenderer.Vertex[4];
+        static int[] _idxImg = new int[] { 0, 2, 1, 1, 2, 3 };
+        
         public static bool TryGetLinkAt(MarkdownDisplayList dl, Vector2 point, Vector2 renderOffset, out string href)
         {
             foreach (var link in dl.Links)

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -465,7 +465,6 @@ namespace Prowl.Scribe
                 return y + h;
             }
             // fallback to alt text
-            // var alt = new List<Inline> { Inline.TextRun(img.Text) };
             var alt = GetInlineList();
             alt.Add(Inline.TextRun(img.Text));
             return LayoutTextSegment(alt, x, y, dl, fontSystem, settings, sizeOverride, lineHeightOverride, fontOverride, widthAvail);

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -404,7 +404,7 @@ namespace Prowl.Scribe
             var (text, decos, linkSpans, styles) = FlattenInlines(inlines);
 
             var baseFont = fontOverride ?? settings.ParagraphFont;
-            var tls = TextLayoutSettings.Default;
+            var tls = TextLayoutSettings.Get();
             tls.PixelSize = sizeOverride ?? settings.BaseSize;
             tls.LineHeight = lineHeightOverride ?? settings.LineHeight;
             tls.WrapMode = TextWrapMode.Wrap;
@@ -499,7 +499,7 @@ namespace Prowl.Scribe
                 else
                 {
                     // right-aligned number inside bulletBox
-                    var tlsNum = TextLayoutSettings.Default;
+                    var tlsNum = TextLayoutSettings.Get();
                     tlsNum.PixelSize = settings.BaseSize;
                     tlsNum.LineHeight = settings.LineHeight;
                     tlsNum.WrapMode = TextWrapMode.NoWrap;
@@ -552,7 +552,7 @@ namespace Prowl.Scribe
             float innerX = x + pad;
             float innerW = MathF.Max(0, wAvail - 2 * pad);
 
-            var tls = TextLayoutSettings.Default;
+            var tls = TextLayoutSettings.Get();
             tls.PixelSize = settings.BaseSize * 0.95f;
             tls.LineHeight = 1.25f;
             tls.WrapMode = TextWrapMode.Wrap;
@@ -591,7 +591,7 @@ namespace Prowl.Scribe
                 {
                     var cell = row.Cells[c]; 
                     var (text, _, _, styles) = FlattenInlines(cell.Inlines);
-                    var tls = TextLayoutSettings.Default;
+                    var tls = TextLayoutSettings.Get();
                     tls.PixelSize = settings.BaseSize;
                     tls.LineHeight = settings.LineHeight;
                     tls.WrapMode = TextWrapMode.NoWrap;
@@ -644,7 +644,7 @@ namespace Prowl.Scribe
                     var cell = row.Cells[c];
                     var (text, decos, linkSpans, styles) = FlattenInlines(cell.Inlines);
 
-                    var tls = TextLayoutSettings.Default;
+                    var tls = TextLayoutSettings.Get();
                     tls.PixelSize = settings.BaseSize;
                     tls.LineHeight = settings.LineHeight;
                     tls.WrapMode = TextWrapMode.Wrap;

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -40,7 +40,7 @@ namespace Prowl.Scribe
         public RectangleF(float x, float y, float w, float h) { X = x; Y = y; Width = w; Height = h; }
     }
 
-    public struct DrawText : IDrawOp
+    public class DrawText : IDrawOp
     {
         public TextLayout Layout;
         public Vector2 Pos;
@@ -95,7 +95,7 @@ namespace Prowl.Scribe
         }
     }
 
-    public struct DrawQuad : IDrawOp
+    public class DrawQuad : IDrawOp
     {
         public RectangleF Rect;
         public FontColor Color;
@@ -120,7 +120,7 @@ namespace Prowl.Scribe
         }
     }
 
-    public struct DrawImage : IDrawOp
+    public class DrawImage : IDrawOp
     {
         public RectangleF Rect;
         public object Texture;
@@ -291,8 +291,10 @@ namespace Prowl.Scribe
             if (dl == null || dl.Ops.Count == 0) return;
 
             // Batch shape quads into a single DrawQuads call using the font atlas texture.
-            var verts = new List<IFontRenderer.Vertex>(128);
-            var idx = new List<int>(256);
+            _verts.Clear();
+            var verts = _verts;
+            _indices.Clear();
+            var idx = _indices;
             int vbase = 0;
 
             foreach (var op in dl.Ops)
@@ -307,7 +309,11 @@ namespace Prowl.Scribe
 
             if (verts.Count > 0)
             {
+                #if NET5_0_OR_GREATER
+                renderer.DrawQuads(fontSystem.Texture, CollectionsMarshal.AsSpan(verts), CollectionsMarshal.AsSpan(idx));
+                #else
                 renderer.DrawQuads(fontSystem.Texture, verts.ToArray(), idx.ToArray());
+                #endif
             }
 
             // Draw text and images in submission order

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -236,6 +236,25 @@ namespace Prowl.Scribe
         public readonly List<IDrawOp> Ops = new List<IDrawOp>();
         public readonly List<LinkInfo> Links = new List<LinkInfo>();
         public Vector2 Size; // overall width/height used
+
+        private static Stack<MarkdownDisplayList> _pool = new Stack<MarkdownDisplayList>();
+
+        public static MarkdownDisplayList Get()
+        {
+            if (!_pool.TryPop(out MarkdownDisplayList list))
+            {
+                list = new MarkdownDisplayList();
+            }
+            
+            return list;
+        }
+
+        public static void Return(MarkdownDisplayList list)
+        {
+            list.Ops.Clear();
+            list.Links.Clear();
+            _pool.Push(list);
+        }
     }
 
     #endregion
@@ -246,7 +265,7 @@ namespace Prowl.Scribe
 
         public static MarkdownDisplayList Layout(Document doc, FontSystem fontSystem, MarkdownLayoutSettings settings, IMarkdownImageProvider? imageProvider = null)
         {
-            var dl = new MarkdownDisplayList();
+            var dl = MarkdownDisplayList.Get();
             float cursorY = 0;
             float maxRight = 0;
 
@@ -345,6 +364,8 @@ namespace Prowl.Scribe
                     DrawImage.Return(img);
                 }
             }
+            
+            MarkdownDisplayList.Return(dl);
         }
 
         static IFontRenderer.Vertex[] _vertsImg = new IFontRenderer.Vertex[4];

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Prowl.Scribe
 {
@@ -607,12 +608,21 @@ namespace Prowl.Scribe
 
         #region Inline flattening & decorations
 
+        static StringBuilder _stringBuilder = new StringBuilder();
+        static List<DecorationSpan> _decorationSpans = new List<DecorationSpan>();
+        static List<LinkSpan> _linkSpans = new List<LinkSpan>();
+        static List<StyleSpan> _styleSpans = new List<StyleSpan>();
+        
         private static (string text, List<DecorationSpan> decos, List<LinkSpan> links, List<StyleSpan> styles) FlattenInlines(List<Inline> inlines)
         {
-            var sb = new System.Text.StringBuilder();
-            var decos = new List<DecorationSpan>();
-            var links = new List<LinkSpan>();
-            var styles = new List<StyleSpan>();
+            _stringBuilder.Clear();
+            var sb = _stringBuilder;
+            _decorationSpans.Clear();
+            var decos = _decorationSpans;
+            _linkSpans.Clear();
+            var links = _linkSpans;
+            _styleSpans.Clear();
+            var styles = _styleSpans;
 
             void EmitText(string s, bool bold, bool italic)
             {

--- a/Scribe/MarkdownLayoutEngine.cs
+++ b/Scribe/MarkdownLayoutEngine.cs
@@ -283,6 +283,7 @@ namespace Prowl.Scribe
             }
 
             dl.Size = new Vector2(settings.Width, cursorY);
+            
             return dl;
         }
         

--- a/Scribe/MarkdownParser.cs
+++ b/Scribe/MarkdownParser.cs
@@ -213,30 +213,16 @@ namespace Prowl.Scribe
     public static class Markdown
     {
         private static Dictionary<ulong, Document> _documentCache = new Dictionary<ulong, Document>();
-        // Entry point
-
 
         public static void ClearDocumentCache()
         {
             _documentCache.Clear();
         }
-        private static ulong ComputeFNV1aHash(string input)
-        {
-            const ulong FNVOffsetBasis = 14695981039346656037UL;
-            const ulong FNVPrime = 1099511628211UL;
 
-            ulong hash = FNVOffsetBasis;
-            foreach (byte b in Encoding.UTF8.GetBytes(input))
-            {
-                hash ^= b;
-                hash *= FNVPrime;
-            }
-            return hash;
-        }
-        
+        // Entry point
         public static Document Parse(string input)
         {
-            ulong hash = ComputeFNV1aHash(input);
+            ulong hash = ComputeFnv1AHash(input);
             
             if (_documentCache.TryGetValue(hash, out Document document))
             {
@@ -928,6 +914,20 @@ namespace Prowl.Scribe
             return arr;
         }
 
+        private static ulong ComputeFnv1AHash(string input)
+        {
+            ulong fnvOffsetBasis = 14695981039346656037UL;
+            ulong fnvPrime = 1099511628211UL;
+
+            ulong hash = fnvOffsetBasis;
+            foreach (byte b in Encoding.UTF8.GetBytes(input))
+            {
+                hash ^= b;
+                hash *= fnvPrime;
+            }
+            return hash;
+        }
+        
         #endregion
     }
 

--- a/Scribe/MarkdownParser.cs
+++ b/Scribe/MarkdownParser.cs
@@ -226,7 +226,7 @@ namespace Prowl.Scribe
             const ulong FNVPrime = 1099511628211UL;
 
             ulong hash = FNVOffsetBasis;
-            foreach (byte b in System.Text.Encoding.UTF8.GetBytes(input))
+            foreach (byte b in Encoding.UTF8.GetBytes(input))
             {
                 hash ^= b;
                 hash *= FNVPrime;

--- a/Scribe/Primitives.cs
+++ b/Scribe/Primitives.cs
@@ -79,6 +79,8 @@ namespace Prowl.Scribe
         public TextWrapMode WrapMode;
         public TextAlignment Alignment;
         public float MaxWidth; // for wrapping, 0 = no limit
+        public List<StyleSpan> StyleSpans;
+        public MarkdownLayoutSettings LayoutSettings;
 
         public Func<int, FontFile> FontSelector; // optional: index in the full string -> font
 
@@ -91,7 +93,8 @@ namespace Prowl.Scribe
             TabSize = 4,
             WrapMode = TextWrapMode.NoWrap,
             Alignment = TextAlignment.Left,
-            MaxWidth = 0
+            MaxWidth = 0,
+            StyleSpans = new List<StyleSpan>()
         };
     }
 

--- a/Scribe/Primitives.cs
+++ b/Scribe/Primitives.cs
@@ -160,8 +160,6 @@ namespace Prowl.Scribe
         public int StartIndex; // character index in original string
         public int EndIndex; // character index in original string
         public static Stack<Line> _pool = new Stack<Line>();
-        public static int _created = 0;
-        public static int _returned = 0;
         public Line(Vector2 position, int startIndex)
         {
             Glyphs = new List<GlyphInstance>();
@@ -177,7 +175,6 @@ namespace Prowl.Scribe
             if (!_pool.TryPop(out Line line))
             {
                 line = new Line(position, startIndex);
-                _created++;
             }
 
             line.Position = position;
@@ -194,13 +191,6 @@ namespace Prowl.Scribe
             }
             line.Glyphs.Clear();
             _pool.Push(line);
-            _returned++;
-        }
-
-        public static void ResetCounters()
-        {
-            _returned = 0;
-            _created = 0;
         }
     }
 }

--- a/Scribe/Primitives.cs
+++ b/Scribe/Primitives.cs
@@ -82,7 +82,8 @@ namespace Prowl.Scribe
         public List<StyleSpan> StyleSpans;
         public MarkdownLayoutSettings LayoutSettings;
 
-        private static Stack<TextLayoutSettings> _pool = new Stack<TextLayoutSettings>();
+        private static List<TextLayoutSettings> _pool = new List<TextLayoutSettings>();
+        private static int _currIdx = 0;
         
         public static TextLayoutSettings Default => new TextLayoutSettings {
             PixelSize = 16,
@@ -115,9 +116,16 @@ namespace Prowl.Scribe
         
         public static TextLayoutSettings Get()
         {
-            if (!_pool.TryPop(out TextLayoutSettings settings))
+            TextLayoutSettings settings;
+            if (_currIdx == 0)
             {
                 settings = new TextLayoutSettings();
+                _pool.Add(settings);
+            }
+            else
+            {
+                settings = _pool[_currIdx];
+                _currIdx--;
             }
             
             settings.SetDefaultValues();
@@ -127,7 +135,9 @@ namespace Prowl.Scribe
         public static void Return(TextLayoutSettings settings)
         {
             settings.StyleSpans.Clear();
-            _pool.Push(settings);
+            if(_currIdx+1 < _pool.Count) _currIdx++;
+        }
+
         }
     }
 

--- a/Scribe/TextLayout.cs
+++ b/Scribe/TextLayout.cs
@@ -224,9 +224,11 @@ namespace Prowl.Scribe
                 {
                     char c = text[j];
 
-                    FontFile font = Settings.Font;
-                    if (Settings.FontSelector != null)
-                        font = Settings.FontSelector(j);
+                    // FontFile font = Settings.Font;
+                    FontFile font = ResolveFontForIndex(j, fontSystem, Settings.Font, Settings.StyleSpans,
+                        Settings.LayoutSettings);
+                    // if (Settings.FontSelector != null)
+                    //     font = Settings.FontSelector(j);
                     var g = fontSystem.GetOrCreateGlyph(c, pixelSize, font);
 
                     //var g = fontSystem.GetOrCreateGlyph(c, pixelSize, Settings.PreferredFont);
@@ -255,6 +257,21 @@ namespace Prowl.Scribe
                 FinalizeLine(ref line, currentY, lineHeight, i, currentX);
         }
 
+        private static FontFile ResolveFontForIndex(int idx, FontSystem fs, FontFile baseFont, List<StyleSpan> spans, MarkdownLayoutSettings settings)
+        {
+            bool bold = false, italic = false;
+            for (int i = 0; i < spans.Count; i++)
+            {
+                var s = spans[i];
+                if (idx >= s.Start && idx < s.End) { bold |= s.Bold; italic |= s.Italic; if (bold && italic) break; }
+            }
+
+            if (bold && italic) return settings.BoldItalicFont;
+            if (bold) return settings.BoldFont;
+            if (italic) return settings.ItalicFont;
+            return baseFont;
+        }
+        
         // Split a too-long word across lines, char by char, with minimal overhead.
         // Note: we do not kern across line starts; inside a run we keep kerning.
         private int LayoutLongWordFast(

--- a/Scribe/TextLayout.cs
+++ b/Scribe/TextLayout.cs
@@ -31,6 +31,9 @@ namespace Prowl.Scribe
             }
             
             layout.Lines.Clear();
+            
+            TextLayoutSettings.Return(layout.Settings);
+            
             _pool.Push(layout);
         }
         public TextLayout()

--- a/Scribe/TextLayout.cs
+++ b/Scribe/TextLayout.cs
@@ -80,9 +80,8 @@ namespace Prowl.Scribe
 
             // Kerning baseline: do NOT kern across whitespace
             int lastCodepointForKerning = 0;
-
-            // Ascender cache per font object; we only need 'a' to place the glyph vertically
-
+            _ascenderCache.Clear();
+            
             while (i < len)
             {
                 char ch = text[i];
@@ -154,9 +153,8 @@ namespace Prowl.Scribe
                 {
                     char c = text[j];
 
-                    FontFile font = Settings.Font;
-                    if (Settings.FontSelector != null)
-                        font = Settings.FontSelector(j);
+                    FontFile font = ResolveFontForIndex(i, fontSystem, Settings.Font, Settings.StyleSpans,
+                        Settings.LayoutSettings);
                     var g = fontSystem.GetOrCreateGlyph(c, pixelSize, font);
 
                     //var g = fontSystem.GetOrCreateGlyph(c, pixelSize, Settings.PreferredFont);
@@ -228,12 +226,9 @@ namespace Prowl.Scribe
                 for (int j = wordStart; j < wordEnd; j++)
                 {
                     char c = text[j];
-
-                    // FontFile font = Settings.Font;
+                    
                     FontFile font = ResolveFontForIndex(j, fontSystem, Settings.Font, Settings.StyleSpans,
                         Settings.LayoutSettings);
-                    // if (Settings.FontSelector != null)
-                    //     font = Settings.FontSelector(j);
                     var g = fontSystem.GetOrCreateGlyph(c, pixelSize, font);
 
                     //var g = fontSystem.GetOrCreateGlyph(c, pixelSize, Settings.PreferredFont);
@@ -301,8 +296,6 @@ namespace Prowl.Scribe
 
                 FontFile font = ResolveFontForIndex(i, fontSystem, Settings.Font, Settings.StyleSpans,
                     Settings.LayoutSettings);
-                // if (Settings.FontSelector != null)
-                //     font = Settings.FontSelector(i);
                 var g = fontSystem.GetOrCreateGlyph(c, pixelSize, font);
 
                 //var g = fontSystem.GetOrCreateGlyph(c, pixelSize, Settings.PreferredFont);

--- a/Scribe/TextLayout.cs
+++ b/Scribe/TextLayout.cs
@@ -40,8 +40,6 @@ namespace Prowl.Scribe
             int i = 0;
             bool hasTrailingNewline = false;
 
-            Lines.Clear();
-
             var line = new Line(new Vector2(0, currentY), 0);
 
             // Hoist Settings & constants


### PR DESCRIPTION
The goal is to reduce the number of allocations in Scribe to increase the performance. I am creating this pull request so others can look at the code and help with the optimization. Outcome is a 99% reduction in the allocation rate and 99% decrease in the number of GC events

### Using Markdown layout system
## Before
Allocation Rate: 864 MiB
GC Count: ~71/frame
<img width="311" height="114" alt="image" src="https://github.com/user-attachments/assets/18023830-4b84-4f72-b524-a49bfe963381" />
<img width="546" height="315" alt="image" src="https://github.com/user-attachments/assets/43a854f8-c378-4bb0-ab15-57e60cb6bc98" />

## After
Allocation Rate: 6.53 MiB
Allocations/Frame: ~38/frame
GC Count: <1/second
<img width="297" height="117" alt="image" src="https://github.com/user-attachments/assets/e6f56f13-1434-4232-8dec-55038a51ca72" />
<img width="548" height="342" alt="image" src="https://github.com/user-attachments/assets/4f6f2b9e-9d36-415e-a192-616da9451be9" />

The markdown demo is by far the most demanding on the system. For the other demos, just rendering text is now extremely fast
## Before
<img width="320" height="116" alt="image" src="https://github.com/user-attachments/assets/86b3e7d1-f769-483c-9d38-6ed76e300b11" />

## After
<img width="315" height="108" alt="image" src="https://github.com/user-attachments/assets/70d247a7-df25-467a-aba2-050f53fa4e99" />

